### PR TITLE
Fix 404 error on vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "build",
+  "framework": "vite",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Add `vercel.json` to configure Vercel deployment, resolving 404 errors by specifying the correct build output directory and enabling client-side routing.

The 404 error occurred because Vercel's default build output directory for Vite projects (`dist`) did not match the app's configured output (`build`). This PR explicitly sets the `outputDirectory` to `build` and adds `rewrites` to ensure client-side routes (e.g., `/game-lobby`) are handled correctly by the single-page application.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2aa0d11-350a-4851-bd39-b50e7cb6fd54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e2aa0d11-350a-4851-bd39-b50e7cb6fd54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

